### PR TITLE
Fix bug

### DIFF
--- a/src/utils/express/protectedMiddleware.js
+++ b/src/utils/express/protectedMiddleware.js
@@ -6,7 +6,7 @@
 // TODO Write tests
 module.exports = (requiredPermissions) => async (req, res, next) => {
   if (!res.locals.volunteer) res.sendStatus(401);
-  if (
+  else if (
     requiredPermissions.every((permission) =>
       res.locals.volunteer.permissions.includes(permission)
     )


### PR DESCRIPTION
`res.locals.volunteer.permissions` throws an error when `res.locals.volunteer` is undefined