### PR TITLE
Make jest tests run in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "node src/launch.js",
     "dev": "nodemon src/launch.js",
-    "test": "jest --runInBand",
+    "test": "jest",
     "doc": "apidoc -i ./src -o ./docs && open-cli ./docs/index.html",
     "depcheck": "depcheck . --ignores=\"eslint*\" --ignore-dirs=\"coverage,docs\"",
     "lint": "eslint --fix .",


### PR DESCRIPTION
For the research I've done, we can run jest tests in parallel which is **significantly** faster.