### PR TITLE
Print complete verification link instead of only token during debugging

### DIFF
--- a/src/auth/verificationAPI.js
+++ b/src/auth/verificationAPI.js
@@ -19,13 +19,13 @@ module.exports.verifyLoginAndSendEmail = async (emailAddress) => {
 
   const token = await signToken({ id: volunteer._id }, EMAIL_EXPIRY);
 
-  log.debug(token);
-
   const verificationLink =
     getConfig().urls.backendHost +
     getConfig().urls.emailLink +
     "?token=" +
     token;
+
+  log.debug(verificationLink);
 
   return sendVerificationEmail(emailAddress, verificationLink);
 };


### PR DESCRIPTION
Prints in console the verification link (what's sent to your email). This allows us to log in without checking our emails. Since it's `log.debug` into won't get printed to Google Cloud logging on production
