### PR TITLE
Switch dependabot to a monthly update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,5 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "monthly"
       timezone: "America/Toronto"


### PR DESCRIPTION
Switch dependabot to notify us monthly since small patch version changes don't need to be applied weekly.